### PR TITLE
exclude grass modules

### DIFF
--- a/src/actinia_ogc_api_processes_plugin/core/process_list.py
+++ b/src/actinia_ogc_api_processes_plugin/core/process_list.py
@@ -76,6 +76,12 @@ def get_modules(limit: int | None = None):
             "version"
         ]
         for el in json.loads(resp_grass_modules.text)["processes"]:
+            if not (
+                el["id"].startswith("d.")
+                or el["id"] == "g.gui"
+                or el["id"].startswith("g.gui.")
+            ):
+                continue
             resp_format["processes"].append(
                 {
                     "id": el["id"],


### PR DESCRIPTION
This PR filters display modules (d.*) and GUI modules (g.gui ) from the GRASS module list.
Related issue: #10